### PR TITLE
Implement Listener Token Renewal in hyco-ws [Connection errors out after ~1 hour]

### DIFF
--- a/examples/hyco-websocket-simple/listener.js
+++ b/examples/hyco-websocket-simple/listener.js
@@ -36,6 +36,6 @@ if ( process.argv.length < 6) {
         });       
     
     wss.on('error', function(err) {
-      console.log('error' + err);
+      console.log('error: ' + err);
     });
 }

--- a/examples/hyco-ws-serverstats/server.js
+++ b/examples/hyco-ws-serverstats/server.js
@@ -23,7 +23,8 @@ if ( process.argv.length < 6) {
     WebSocket.createRelayedServer(
         {
             server : WebSocket.createRelayListenUri(_ns, _path),
-            token: WebSocket.createRelayToken('http://'+_ns, _keyrule, _key)
+            keyName: _keyrule,
+            key: _key
         }, function(ws) {
             var id = setInterval(function() {
               ws.send(JSON.stringify(process.memoryUsage()), function() { /* ignore errors */ });

--- a/examples/hyco-ws-simple/listener.js
+++ b/examples/hyco-ws-simple/listener.js
@@ -13,7 +13,8 @@ if ( process.argv.length < 6) {
     var wss = WebSocket.createRelayedServer(
         {
             server : WebSocket.createRelayListenUri(ns, path),
-            token: WebSocket.createRelayToken('http://'+ns, keyrule, key)
+            keyName: keyrule,
+            key: key
         }, 
         function (ws) {
             console.log('connection accepted');
@@ -23,9 +24,10 @@ if ( process.argv.length < 6) {
             ws.on('close', function () {
                 console.log('connection closed');
             });       
-    });
+        }
+    );
 
     wss.on('error', function(err) {
-    console.log('error' + err);
+        console.log('error: ' + err);
     });
 }

--- a/examples/hyco-ws-simple/listener.js
+++ b/examples/hyco-ws-simple/listener.js
@@ -19,7 +19,7 @@ if ( process.argv.length < 6) {
         function (ws) {
             console.log('connection accepted');
             ws.onmessage = function (event) {
-                console.log(JSON.parse(event.data));
+                console.log('onmessage: ' + event.data);
             };
             ws.on('close', function () {
                 console.log('connection closed');

--- a/hyco-websocket/index.js
+++ b/hyco-websocket/index.js
@@ -6,33 +6,43 @@ var url = require('url');
 
 var WS = module.exports = require('./lib/hybridconnectionswebsocket');
 
-WS.createRelayToken = function createRelayToken(uri, key_name, key, expiry) {
-    // Token expires in one hour
+/**
+ * Create a Relay Token
+ *
+ * @param {String} address The URL/address we need to connect to.
+ * @param {String} key_name The SharedAccessSignature key name.
+ * @param {String} key The SharedAccessSignature key value.
+ * @param {number} expirationSeconds Optional number of seconds until the generated token should expire.  Default is 1 hour (3600) if not specified.
+ * @api public
+ */
+WS.createRelayToken = function createRelayToken(uri, key_name, key, expirationSeconds) {
     var parsedUrl = url.parse(uri);
     parsedUrl.protocol = "http";
     parsedUrl.search = parsedUrl.hash = parsedUrl.port = null;
     parsedUrl.pathname = parsedUrl.pathname.replace('$hc/','');
     uri = url.format(parsedUrl);
 
-    if ( expiry == null) {
-       expiry = moment().add(1, 'hours').unix();
+    if (!expirationSeconds) {
+      // Token expires in one hour (3600 seconds)
+      expirationSeconds = 3600;
     }
-    var string_to_sign = encodeURIComponent(uri) + '\n' + expiry;
+
+    var unixSeconds = moment().add(expirationSeconds, 'seconds').unix();
+    var string_to_sign = encodeURIComponent(uri) + '\n' + unixSeconds;
     var hmac = crypto.createHmac('sha256', key);
     hmac.update(string_to_sign);
     var signature = hmac.digest('base64');
-    var token = 'SharedAccessSignature sr=' + encodeURIComponent(uri) + '&sig=' + encodeURIComponent(signature) + '&se=' + expiry + '&skn=' + key_name;
+    var token = 'SharedAccessSignature sr=' + encodeURIComponent(uri) + '&sig=' + encodeURIComponent(signature) + '&se=' + unixSeconds + '&skn=' + key_name;
     return token;
 };
 
-WS.appendRelayToken = function appendRelayToken(uri, key_name, key, expiry) {
-   var token = WS.createRelayToken(uri, key_name, key, expiry);
+WS.appendRelayToken = function appendRelayToken(uri, key_name, key, expirationSeconds) {
+   var token = WS.createRelayToken(uri, key_name, key, expirationSeconds);
 
     var parsedUrl = url.parse(uri);
     parsedUrl.search = parsedUrl.search + '&sb-hc-token=' + encodeURIComponent(token);
     return url.format(parsedUrl);
 }
-
 
 WS.createRelayBaseUri = function createRelayBaseUri(serviceBusNamespace, path) {
     return 'wss://' + serviceBusNamespace + ':443/$hc/' + path;

--- a/hyco-ws/examples/simple/listener.js
+++ b/hyco-ws/examples/simple/listener.js
@@ -23,7 +23,8 @@ if ( args.ns == null || args.path == null || args.keyrule == null || args.key ==
     var wss = WebSocket.createRelayedServer(
         {
             server : uri,
-            token: WebSocket.createRelayToken(uri, args.keyrule, args.key)
+            keyName: args.keyrule,
+            key: args.key
         }, 
         function (ws) {
             console.log('connection accepted');


### PR DESCRIPTION
- Add new options "keyName" and "key" alongside "token" when calling WebSocket.createRelayedServer so that the relay listener is capable of generating new tokens.
- If these new options, "keyName" and "key" were used then set up a timer (setInterval) which renews the Listener Token as long as that controlChannel(WebSocket) remains open.

Addresses issue #8 for 'hyco-ws'.