### PR TITLE
Handling request body in control channel

### DIFF
--- a/hyco-https/examples/simple/listener.js
+++ b/hyco-https/examples/simple/listener.js
@@ -26,6 +26,9 @@ if (args.ns == null || args.path == null || args.keyrule == null || args.key == 
             token : () => https.createRelayToken(uri, args.keyrule, args.key)
         },
         (req, res) => {
+            req.connection.on('message', (msg) => {
+              // consume the request body explicitly
+            });
             console.log('request accepted: ' + req.method + ' on ' + req.url);
             res.setHeader('Content-Type', 'text/html');
             res.end('<html><head><title>Hey!</title></head><body>Relayed Node.js Server!</body></html>');

--- a/hyco-https/lib/HybridConnectionHttpsServer.js
+++ b/hyco-https/lib/HybridConnectionHttpsServer.js
@@ -117,7 +117,6 @@ util.inherits(ServerResponse, OutgoingMessage);
 
 ServerResponse.prototype._finish = function _finish() {
   DTRACE_HTTP_SERVER_RESPONSE(this.connection);
-  COUNTER_HTTP_SERVER_RESPONSE();
   OutgoingMessage.prototype._finish.call(this);
 };
 
@@ -611,7 +610,7 @@ function controlChannelRequest(server, message) {
 /* 
  * accept a control-channel request
  */
-function requestChannelRequest(channel, message) {
+function requestChannelRequest(server, channel, message) {
   try {
     var res = null;
     // do we have a request or is this just rendezvous?
@@ -631,7 +630,7 @@ function requestChannelListener(server, requestChannel) {
     
     if (isDefinedAndNonNull(message, 'request')) {
       // HTTP request
-      requestChannelRequest(requestChannel, message);
+      requestChannelRequest(server, requestChannel, message);
     }
   };
 }


### PR DESCRIPTION
## Description

This patch fix a few issues:

- Remove use of `COUNTER_HTTP_SERVER_RESPONSE`, which is undefined in newer version of nodejs
- Pass `server` argument to `requestChannelRequest`
- Explicitly consumes request body in the listener example, so that POST request sending through the control channel won't crash the listener. Note that the `stream` interface inheritance does not seem to work as expected.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] The code builds without any errors.