### PR TITLE
Fixing support for express.js

### DIFF
--- a/hyco-https/lib/HybridConnectionHttpsServer.js
+++ b/hyco-https/lib/HybridConnectionHttpsServer.js
@@ -653,6 +653,8 @@ function requestChannelListener(server, requestChannel) {
     
     if ( requestChannel.pendingRequest != null )
     {
+      requestChannel.pendingRequest.handleBody = IncomingMessage.prototype.handleBody;
+      requestChannel.pendingRequest.destroy = IncomingMessage.prototype.destroy;
       requestChannel.pendingRequest.handleBody(event.data);
       requestChannel.pendingRequest = null;
       return;


### PR DESCRIPTION

## Description
Assigning functions to 'handleBody' and 'destroy' based on IncomingMessage class own implementations.
This fixes express.js POST support for small/large payloads